### PR TITLE
Fixed parameter passing in engine, made everything local to imperative_parser to maintain state

### DIFF
--- a/config_parser/default.skit
+++ b/config_parser/default.skit
@@ -36,7 +36,7 @@ default: {
                     name: "Victory Point Card",
                     description: "1 Victory Point!\n Reveal this card on your turn if, with it, you reach the number of points required for victory.",
                     count: 5,
-                    draw-card: func(game, player) {
+                    draw-card: func(player) {
                         player.hidden_points += 1
                     }
                 },

--- a/engine/src/input_manager.py
+++ b/engine/src/input_manager.py
@@ -209,7 +209,7 @@ class InputManager(cmd.Cmd):
 
             try:
                 dev_card = self.game.board.bank.buy_development_card(self.player)
-                dev_card.draw_card(self.game, self.player)
+                dev_card.draw_card()
 
                 success_msg = 'You received a {0}!'.format(str(dev_card))
 
@@ -244,7 +244,7 @@ class InputManager(cmd.Cmd):
                 return
 
             try:
-                dev_card.play_card(self.game, self.player)
+                dev_card.play_card()
                 self.game.update_point_counts()
 
             # TODO: Make clear which exceptions can be caught.

--- a/imperative_parser/oracle.py
+++ b/imperative_parser/oracle.py
@@ -49,9 +49,7 @@ class GameOracle(object):
             name (String): A string representing the name to store the variable under
             var (Any): The value to store for the variable
         """
-        if self.game_state[name]:
-            self.game_state[name].pop()
-        self.game_state[name].append(var)
+        self.game_state[name] = var
 
 # Access game state through the game oracle
 ORACLE = GameOracle(defaultdict(list))

--- a/imperative_parser/parser.py
+++ b/imperative_parser/parser.py
@@ -158,7 +158,15 @@ def p_assign_lst(p):
                   | store_id"""
     p = listify(p)
 
-p_store_other = trivial('store_id', ['property', 'getitem'])
+def p_store_property(p):
+    """store_id : property"""
+    p[1].ctx = ast.Store()
+    p[0] = p[1]
+
+def p_store_getitem(p):
+    """store_id : getitem"""
+    p[1].ctx = ast.Store()
+    p[0] = p[1]
 
 @register('expr')
 def p_num(p):

--- a/imperative_parser/test/test_parser.py
+++ b/imperative_parser/test/test_parser.py
@@ -265,6 +265,7 @@ class ParsingBehaviorTests(unittest.TestCase):
         func = self.compileFunc("func(test) { return test }")
         test.append(1)
 
+
         self.assertResult(func, test)
 
         test.pop()

--- a/imperative_parser/test/test_parser.py
+++ b/imperative_parser/test/test_parser.py
@@ -33,6 +33,12 @@ class ParsingASTTests(unittest.TestCase):
     def test_multi_stmt_assignment(self):
         self.assertSameParse("a, b = tpl", "a, b = tpl")
 
+    def test_stmt_assign_property(self):
+        self.assertSameParse("a.b.c = 1", "a.b.c = 1")
+
+    def test_stmt_assign_getitem(self):
+        self.assertSameParse("a['b']['c'] = 1", 'a["b"]["c"] = 1')
+
     def test_stmt_aug_assign_add(self):
         self.assertSameParse("test += 1", "test += 1")
 
@@ -264,7 +270,6 @@ class ParsingBehaviorTests(unittest.TestCase):
 
         func = self.compileFunc("func(test) { return test }")
         test.append(1)
-
 
         self.assertResult(func, test)
 


### PR DESCRIPTION
Fixed the issue with development cards not working, something was weird in the way they're getting attached to objects / passed through the config parser, so I changed the way references are handled to isolate everything in the imperative_parser. It's a bit weird from an architecture perspective, but it works for getting this done.